### PR TITLE
Fix HTML placeholders and update links

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -22,7 +22,7 @@
   MathJax.Hub.Config({tex2jax: {inlineMath: [['$','$'], ['\\(','\\)']]}});
 </script>
 <script type="text/javascript"
-  src="http://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS-MML_HTMLorMML">
+  src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS-MML_HTMLorMML">
 </script>
 </head>
 

--- a/footer.html
+++ b/footer.html
@@ -1,4 +1,3 @@
-<div id="footer-placeholder"></div>
 <footer>
     &copy; 2025 Peter Gracar
 </footer>

--- a/header.html
+++ b/header.html
@@ -1,4 +1,3 @@
-<div id="header-placeholder"></div>
 <header>
     <div class="banner">
         <h1>Peter Gracar</h1>

--- a/index.html
+++ b/index.html
@@ -31,7 +31,7 @@
   MathJax.Hub.Config({tex2jax: {inlineMath: [['$','$'], ['\\(','\\)']]}});
 </script>
 <script type="text/javascript"
-  src="http://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS-MML_HTMLorMML">
+  src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS-MML_HTMLorMML">
 </script>
 </head>
 

--- a/map.html
+++ b/map.html
@@ -22,7 +22,7 @@
   MathJax.Hub.Config({tex2jax: {inlineMath: [['$','$'], ['\\(','\\)']]}});
 </script>
 <script type="text/javascript"
-  src="http://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS-MML_HTMLorMML">
+  src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS-MML_HTMLorMML">
 </script>
 </head>
 

--- a/research.html
+++ b/research.html
@@ -22,7 +22,7 @@
   MathJax.Hub.Config({tex2jax: {inlineMath: [['$','$'], ['\\(','\\)']]}});
 </script>
 <script type="text/javascript"
-  src="http://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS-MML_HTMLorMML">
+  src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS-MML_HTMLorMML">
 </script>
 </head>
 
@@ -33,7 +33,7 @@
             <h2>Current Work</h2>
             <p>My research explores <span class="hover-image"><b>geometric random graphs</b>
         <img src="img/sumkernel.webp" alt="Sum kernel" class="hover-img">,
-      </span> their implications for random processes. I also study <span class="hover-image"><b>dependent percolation</b><img src="img/lipschitz.webp" alt="Lipshitz percolation" class="hover-img">
+      </span> their implications for random processes. I also study <span class="hover-image"><b>dependent percolation</b><img src="img/lipschitz.webp" alt="Lipschitz percolation" class="hover-img">
       </span> using multi-scale techniques. Publications and preprints can be found below. You can also check my <b><a href="http://arxiv.org/a/gracar_p_1">arXiv</a></b> or <b><a href="https://orcid.org/0000-0001-8340-8340">ORCiD</a></b> pages.</p>
         </section>
         <section>
@@ -48,7 +48,7 @@
                 <li><b><a href="https://arxiv.org/pdf/2404.15124">Geometric scale-free random graphs on mobile vertices: broadcast and percolation times</a></b>
                     <br> with Arne Grauer, <i><a href="https://arxiv.org/abs/2404.15124">arXiv:2404.15124</a></i>
                 </li>
-                <li><b><a href="https://arxiv.org/pfd/2203.11966">Finiteness of the percolation threshold for inhomogeneous long-range models in one dimension</a></b>
+                <li><b><a href="https://arxiv.org/pdf/2203.11966">Finiteness of the percolation threshold for inhomogeneous long-range models in one dimension</a></b>
                     <br> with Lukas Lüchtrath and Christian Mönch, <i><a href="https://arxiv.org/abs/2203.11966">arXiv:2203.11966</a></i>
                 </li>
             </ul>

--- a/teaching.html
+++ b/teaching.html
@@ -22,7 +22,7 @@
   MathJax.Hub.Config({tex2jax: {inlineMath: [['$','$'], ['\\(','\\)']]}});
 </script>
 <script type="text/javascript"
-  src="http://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS-MML_HTMLorMML">
+  src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS-MML_HTMLorMML">
 </script>
 </head>
 


### PR DESCRIPTION
## Summary
- remove extraneous placeholder divs from `header.html` and `footer.html`
- use HTTPS for MathJax on all pages
- fix typo in research paper link and alt text

## Testing
- `tidy -errors -q index.html`
- `tidy -errors -q contact.html`
- `tidy -errors -q map.html`
- `tidy -errors -q research.html`
- `tidy -errors -q teaching.html`


------
https://chatgpt.com/codex/tasks/task_e_68407e1a376083208f00a53074b9d4aa