### PR TITLE
Fix broken links and cleanup HTML

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -22,7 +22,7 @@
   MathJax.Hub.Config({tex2jax: {inlineMath: [['$','$'], ['\\(','\\)']]}});
 </script>
 <script type="text/javascript"
-  src="http://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS-MML_HTMLorMML">
+  src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS-MML_HTMLorMML">
 </script>
 </head>
 

--- a/footer.html
+++ b/footer.html
@@ -1,4 +1,3 @@
-<div id="footer-placeholder"></div>
 <footer>
     &copy; 2025 Peter Gracar
 </footer>

--- a/header.html
+++ b/header.html
@@ -1,4 +1,3 @@
-<div id="header-placeholder"></div>
 <header>
     <div class="banner">
         <h1>Peter Gracar</h1>

--- a/index.html
+++ b/index.html
@@ -31,7 +31,7 @@
   MathJax.Hub.Config({tex2jax: {inlineMath: [['$','$'], ['\\(','\\)']]}});
 </script>
 <script type="text/javascript"
-  src="http://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS-MML_HTMLorMML">
+  src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS-MML_HTMLorMML">
 </script>
 </head>
 
@@ -41,7 +41,7 @@
         <section>
             <h2>About</h2>
             <div class="media">
-                <img src="img/avatar.webp" alt="Description">
+                <img src="img/avatar.webp" alt="Photo of Peter Gracar">
                 <div>
                     <p>Hi, my name is Peter and I'm a <b><a href="https://eps.leeds.ac.uk/maths/staff/13156/dr-peter-gracar">Lecturer in Probability</a></b> in the Statistics Department of the <b><a href="https://eps.leeds.ac.uk/maths">School of Mathematics</a></b>                        at the <b><a href="https://www.leeds.ac.uk">University of Leeds</a></b>.</p>
                     <p>My main focus of research lie in random (geometric) graphs, particle systems and more broadly percolation theory. More details, as well as my publication list can be found on the <b><a href="research.html">research</a></b> page.</p>
@@ -53,7 +53,7 @@
             <h3>Short CV</h3>
             <ul>
                 <li><b>2023-present</b>: Lecturer in Probability, University of Leeds</li>
-                <li><b>2017-2023</b>: PostDoc in the <b><a href="http://www.mi.uni-koeln.de/agmoerters/">Research Group of Peter Mörters</a></b>, University of Cologne</li>
+                <li><b>2017-2023</b>: PostDoc in the <b><a href="https://www.mi.uni-koeln.de/agmoerters/">Research Group of Peter Mörters</a></b>, University of Cologne</li>
                 <li><b>2014-2017</b>: PhD in Probability (supervisor: <b><a href="https://sites.google.com/site/alexandrestauffer/home">Alexandre Stauffer</a></b>), University of Bath</li>
                 <li><b>2013-2014</b>: Forensic consultant, Deloitte AG, Zürich</li>
                 <li><b>2011-2013</b>: MSc in Quantitative Finance, University of Zürich and ETH Zürich</li>

--- a/map.html
+++ b/map.html
@@ -22,7 +22,7 @@
   MathJax.Hub.Config({tex2jax: {inlineMath: [['$','$'], ['\\(','\\)']]}});
 </script>
 <script type="text/javascript"
-  src="http://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS-MML_HTMLorMML">
+  src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS-MML_HTMLorMML">
 </script>
 </head>
 

--- a/research.html
+++ b/research.html
@@ -22,7 +22,7 @@
   MathJax.Hub.Config({tex2jax: {inlineMath: [['$','$'], ['\\(','\\)']]}});
 </script>
 <script type="text/javascript"
-  src="http://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS-MML_HTMLorMML">
+  src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS-MML_HTMLorMML">
 </script>
 </head>
 
@@ -33,8 +33,8 @@
             <h2>Current Work</h2>
             <p>My research explores <span class="hover-image"><b>geometric random graphs</b>
         <img src="img/sumkernel.webp" alt="Sum kernel" class="hover-img">,
-      </span> their implications for random processes. I also study <span class="hover-image"><b>dependent percolation</b><img src="img/lipschitz.webp" alt="Lipshitz percolation" class="hover-img">
-      </span> using multi-scale techniques. Publications and preprints can be found below. You can also check my <b><a href="http://arxiv.org/a/gracar_p_1">arXiv</a></b> or <b><a href="https://orcid.org/0000-0001-8340-8340">ORCiD</a></b> pages.</p>
+      </span> their implications for random processes. I also study <span class="hover-image"><b>dependent percolation</b><img src="img/lipschitz.webp" alt="Lipschitz percolation" class="hover-img">
+      </span> using multi-scale techniques. Publications and preprints can be found below. You can also check my <b><a href="https://arxiv.org/a/gracar_p_1">arXiv</a></b> or <b><a href="https://orcid.org/0000-0001-8340-8340">ORCiD</a></b> pages.</p>
         </section>
         <section>
             <h4>Submitted papers/Preprints</h4>
@@ -48,7 +48,7 @@
                 <li><b><a href="https://arxiv.org/pdf/2404.15124">Geometric scale-free random graphs on mobile vertices: broadcast and percolation times</a></b>
                     <br> with Arne Grauer, <i><a href="https://arxiv.org/abs/2404.15124">arXiv:2404.15124</a></i>
                 </li>
-                <li><b><a href="https://arxiv.org/pfd/2203.11966">Finiteness of the percolation threshold for inhomogeneous long-range models in one dimension</a></b>
+                <li><b><a href="https://arxiv.org/pdf/2203.11966">Finiteness of the percolation threshold for inhomogeneous long-range models in one dimension</a></b>
                     <br> with Lukas Lüchtrath and Christian Mönch, <i><a href="https://arxiv.org/abs/2203.11966">arXiv:2203.11966</a></i>
                 </li>
             </ul>
@@ -88,16 +88,16 @@
                     <br> with Alexandre Stauffer, <i><a href="https://doi.org/10.1016/j.spa.2018.09.016">Stochastic Processes and their Applications</a></i>, 129: 3547-3569 (2019)
                 </li>
                 <li><b><a href="https://arxiv.org/abs/1806.01140">Percolation of Lipschitz surface and tight bounds on the spread of information among mobile agents</a></b></br>
-                    with Alexandre Stauffer, <i><a href="http://drops.dagstuhl.de/opus/volltexte/2018/9443/">APPROX-RANDOM 2018</a></i>, 39: 1-17 (2018)
+                    with Alexandre Stauffer, <i><a href="https://drops.dagstuhl.de/opus/volltexte/2018/9443/">APPROX-RANDOM 2018</a></i>, 39: 1-17 (2018)
                 </li>
                 <!-- <li><b><a href="files/Convex_optimisation_revised.pdf">Aspects of Convex Risk Optimisation</a></b><br>
 								Peter Gracar, Master's Thesis (ETH Zürich, Switzerland, 2013)
 								</li> -->
             </ul>
             <h4>My co-authors</h4>
-            <p><a href="http://www.mi.uni-koeln.de/~drewitz/">Alexander Drewitz</a>, <a href="https://www.linkedin.com/in/gioele-gallo/">Gioele Gallo</a>, <a href="https://sites.google.com/view/arnegrauer/home">Arne Grauer</a>, <a href="https://www.uni-augsburg.de/de/fakultaet/mntf/math/prof/sto/hey/">Markus Heydenreich</a>,
+            <p><a href="https://www.mi.uni-koeln.de/~drewitz/">Alexander Drewitz</a>, <a href="https://www.linkedin.com/in/gioele-gallo/">Gioele Gallo</a>, <a href="https://sites.google.com/view/arnegrauer/home">Arne Grauer</a>, <a href="https://www.uni-augsburg.de/de/fakultaet/mntf/math/prof/sto/hey/">Markus Heydenreich</a>,
                 <a href="https://sites.google.com/view/marilyn-korfhage">Marilyn Korfhage</a>, <a href="https://wias-berlin.de/people/luechtrath/?lang=1">Lukas Lüchtrath</a>, <a href="https://www.stochastik.mathematik.uni-mainz.de/christian-moench/">Christian Mönch</a>,
-                <a href="http://www.mi.uni-koeln.de/~moerters/">Peter Mörters</a>, <a href="https://sites.google.com/site/alexandrestauffer/home">Alexandre Stauffer</a></p>
+                <a href="https://www.mi.uni-koeln.de/~moerters/">Peter Mörters</a>, <a href="https://sites.google.com/site/alexandrestauffer/home">Alexandre Stauffer</a></p>
             <h4>Some conferences/workshops where I have given a talk</h4>
             <ul>
                 <li><b><a href="https://sites.google.com/view/long-range-percolation-cologne/">Long-range phenomena in Percolation</a></b>, Cologne, Germany</li>

--- a/teaching.html
+++ b/teaching.html
@@ -22,7 +22,7 @@
   MathJax.Hub.Config({tex2jax: {inlineMath: [['$','$'], ['\\(','\\)']]}});
 </script>
 <script type="text/javascript"
-  src="http://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS-MML_HTMLorMML">
+  src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS-MML_HTMLorMML">
 </script>
 </head>
 


### PR DESCRIPTION
## Summary
- remove leftover placeholders from `header.html` and `footer.html`
- load MathJax over HTTPS everywhere
- improve avatar alt text and fix some HTTP links
- correct typo in PDF link and spelling of "Lipschitz" in `research.html`

## Testing
- `tidy -e index.html`
- `tidy -e research.html`
- `tidy -e teaching.html`
- `tidy -e contact.html`
- `tidy -e map.html`
- `linkchecker index.html`


------
https://chatgpt.com/codex/tasks/task_e_6840b825e3e48320a800228a31495d1a