### PR TITLE
Fix grammar on homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -44,7 +44,7 @@
                 <img src="img/avatar.webp" alt="Photo of Peter Gracar">
                 <div>
                     <p>Hi, my name is Peter and I'm a <b><a href="https://eps.leeds.ac.uk/maths/staff/13156/dr-peter-gracar">Lecturer in Probability</a></b> in the Statistics Department of the <b><a href="https://eps.leeds.ac.uk/maths">School of Mathematics</a></b>                        at the <b><a href="https://www.leeds.ac.uk">University of Leeds</a></b>.</p>
-                    <p>My main focus of research lie in random (geometric) graphs, particle systems and more broadly percolation theory. More details, as well as my publication list can be found on the <b><a href="research.html">research</a></b> page.</p>
+                    <p>My main focus of research lies in random (geometric) graphs, particle systems and, more broadly, percolation theory. More details, as well as my publication list, can be found on the <b><a href="research.html">research</a></b> page.</p>
                     <p>You might have found this page in error, in which case I wish you all the best on your future journey. If you are a student, you might be here to figure out how to find my office. If that's the case, I suggest you look at this
                         <span
                         class="hover-image"><b>map</b><img src="img/Map.webp" alt="map to office" class="hover-img"></span> or head over to my <b><a href="contact.html">contact</a></b> page to find other ways to get in touch.</p>


### PR DESCRIPTION
## Summary
- fix grammar in the homepage

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6840bafe6e308320b3f549bcad0a35fa