### PR TITLE
Fix navigation highlight for current page

### DIFF
--- a/includeHTML.js
+++ b/includeHTML.js
@@ -5,9 +5,11 @@
     document.getElementById(id + '-placeholder').innerHTML = html;
   }));
 
-  const filename = window.location.pathname.split('/').pop() || 'index.html';
+  const path = window.location.pathname.replace(/\/$/, '');
+  const filename = path.split('/').pop().replace(/\.html$/, '') || 'index';
   document.querySelectorAll('nav a').forEach(a => {
-    if (a.getAttribute('href') === filename) {
+    const link = a.getAttribute('href').replace(/\.html$/, '');
+    if (link === filename) {
       a.classList.add('active');
     }
   });


### PR DESCRIPTION
## Summary
- Improve nav highlighting by stripping trailing slashes and `.html` extensions from current URL and nav links

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c81c1fc8e48320b911019dca1a69c9