### PR TITLE
Fix curly quotes in SDRE26 talk front matter

### DIFF
--- a/_talks/2026-07-6-Spreading dynamics-in-random environment.md
+++ b/_talks/2026-07-6-Spreading dynamics-in-random environment.md
@@ -1,6 +1,6 @@
 ---
 title: "Spreading dynamics in random environments"
 event_url: "https://www.wias-berlin.de/workshops/SDRE26/"
-date: "2026-07-06”
-location: “Berlin, Germany"
+date: "2026-07-06"
+location: "Berlin, Germany"
 ---


### PR DESCRIPTION
Replace Unicode smart quotes (U+201C / U+201D) with ASCII double quotes in the SDRE26 talk's date and location fields, which broke YAML parsing and caused Jekyll to silently skip the entry.

https://claude.ai/code/session_01KYJdPYRd6gALx4B6V5M88R