### PR TITLE
Add Pride Month rainbow easter egg with footer toggle

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -204,6 +204,12 @@ resolve to `/simulations/style.css`, etc., and 404.
 - Highlights the active nav item by matching `data-page-link` against
   `body[data-page]`.
 - Injects the current year into any `[data-year]` node (used in the footer).
+- Pride Month easter egg: during June (`getMonth() === 5`) it adds a `pride`
+  class to `<body>` and reveals the footer `[data-pride-toggle]` button, which
+  CSS uses to draw thin rainbow strips (the `--pride-gradient` token) under the
+  nav and atop the footer. A click toggles the class and persists the choice in
+  `localStorage['pride-colours']` (`"on"`/`"off"`, default on, `try/catch`
+  guarded). The toggle is hidden and the class absent outside June.
 - Wires up `.hover-image` buttons with `.hover-img` children for the figure
   previews on the home and research pages (hover on desktop, click on touch,
   Esc to dismiss, click-outside to dismiss).
@@ -287,8 +293,9 @@ templates and pushing. GitHub Pages rebuilds on push to `main`.
   missing required fields rather than erroring.
 - **CSS**: all styles live in `style.css`. It uses CSS custom properties
   (`--color-*` and `--text-*` — the previous `--space-*` spacing tokens were
-  removed as unused) and a `prefers-color-scheme: dark` block. Prefer
-  extending the existing variables over adding hard-coded values.
+  removed as unused, plus `--pride-gradient` for the June easter egg) and a
+  `prefers-color-scheme: dark` block. Prefer extending the existing variables
+  over adding hard-coded values.
 - **JS**: keep `site.js` small and framework-free. It is a single IIFE that
   short-circuits gracefully when the elements it looks for are absent.
 - **Cache busting**: bump `?v=<n>` on `style.css` / `site.js` in

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -31,7 +31,7 @@
   <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
   <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
   <link rel="manifest" href="/site.webmanifest">
-  <link rel="stylesheet" href="/style.css?v=1">
+  <link rel="stylesheet" href="/style.css?v=2">
 
   {% if page.mathjax %}
   <script>
@@ -58,7 +58,7 @@
   </script>
   {% endunless %}
 
-  <script src="/site.js?v=1" defer></script>
+  <script src="/site.js?v=2" defer></script>
 </head>
 <body data-page="{{ page.data_page }}">
   <a class="skip-link" href="#main-content">Skip to content</a>
@@ -84,6 +84,10 @@
   <footer class="site-footer">
     <div class="site-footer-inner">
       <p>
+        <button type="button" class="pride-toggle" data-pride-toggle hidden aria-pressed="true" title="Pride colours are on this June — toggle off">
+          <span class="pride-flag" aria-hidden="true">🏳️‍🌈</span>
+          <span class="pride-toggle-label">Pride colours</span>
+        </button>
         <a href="https://eps.leeds.ac.uk/maths">School of Mathematics</a> &middot;
         <a href="https://orcid.org/0000-0001-8340-8340">ORCiD</a> &middot;
         <a href="https://arxiv.org/a/gracar_p_1">arXiv</a>

--- a/site.js
+++ b/site.js
@@ -27,6 +27,39 @@
     yearNode.textContent = String(new Date().getFullYear());
   }
 
+  // Pride Month (June) easter egg — auto-on, with a remembered opt-out.
+  const prideToggle = document.querySelector("[data-pride-toggle]");
+  if (prideToggle && new Date().getMonth() === 5) {
+    const prideKey = "pride-colours";
+    const readPride = () => {
+      try {
+        return localStorage.getItem(prideKey);
+      } catch (error) {
+        return null;
+      }
+    };
+    const writePride = (value) => {
+      try {
+        localStorage.setItem(prideKey, value);
+      } catch (error) {
+        /* storage unavailable (e.g. private mode) — preference simply not remembered */
+      }
+    };
+
+    let prideEnabled = readPride() !== "off"; // default on during June
+    const applyPride = () => {
+      body.classList.toggle("pride", prideEnabled);
+      prideToggle.setAttribute("aria-pressed", String(prideEnabled));
+    };
+    applyPride();
+    prideToggle.hidden = false; // reveal the toggle only during Pride Month
+    prideToggle.addEventListener("click", () => {
+      prideEnabled = !prideEnabled;
+      writePride(prideEnabled ? "on" : "off");
+      applyPride();
+    });
+  }
+
   const upcomingTalks = document.querySelectorAll("[data-talk-date]");
   if (upcomingTalks.length) {
     const today = new Date();

--- a/style.css
+++ b/style.css
@@ -14,6 +14,7 @@
   --color-header-overlay: linear-gradient(120deg, rgba(20, 9, 8, 0.8), rgba(90, 18, 16, 0.45));
   --color-nav-bg: rgba(24, 15, 12, 0.66);
   --color-focus: #ff9f4a;
+  --pride-gradient: linear-gradient(90deg, #e40303, #ff8c00, #ffed00, #008026, #004dff, #750787);
 
   --shadow-soft: 0 12px 30px rgba(34, 20, 15, 0.12);
   --shadow-card: 0 6px 18px rgba(34, 20, 15, 0.08);
@@ -212,6 +213,12 @@ button:focus-visible {
 .site-nav a[aria-current="page"] {
   background: var(--color-accent);
   color: #ffffff;
+}
+
+/* Pride Month easter egg: thin rainbow strips under the nav and atop the footer. */
+body.pride .site-nav {
+  border-bottom: 3px solid transparent;
+  border-image: var(--pride-gradient) 1;
 }
 
 main {
@@ -648,6 +655,42 @@ li + li {
 
 .site-footer-inner a:hover {
   color: var(--color-accent);
+}
+
+body.pride .site-footer {
+  border-top: 3px solid transparent;
+  border-image: var(--pride-gradient) 1;
+}
+
+.pride-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  margin-right: 0.4rem;
+  padding: 0;
+  border: 0;
+  background: none;
+  color: var(--color-text-muted);
+  font: inherit;
+  cursor: pointer;
+  transition: opacity var(--transition-fast), color var(--transition-fast);
+}
+
+.pride-toggle:hover .pride-toggle-label {
+  color: var(--color-accent);
+}
+
+.pride-toggle[aria-pressed="false"] {
+  opacity: 0.55;
+}
+
+.pride-toggle[aria-pressed="false"] .pride-toggle-label {
+  text-decoration: line-through;
+}
+
+.pride-flag {
+  font-size: 1.05em;
+  line-height: 1;
 }
 
 @media (min-width: 48rem) {


### PR DESCRIPTION
During June, the site adds a `pride` class to `<body>` and reveals a small 🏳️‍🌈 toggle at the start of the footer. The class draws thin 3px rainbow gradient strips under the nav and along the footer's top border — subtle, leaving all text and the maroon accent untouched.

The toggle persists the choice in `localStorage['pride-colours']` (default on, opt-out remembered, `try/catch` guarded). Outside June the feature is fully dormant (toggle hidden, no class). Because the default stylesheet has no rainbow, opted-out and off-season visitors never see a flash — JS only ever adds the accent.

Changes:
- `_layouts/default.html` — footer toggle markup + `?v=2` cache-bust on both assets
- `style.css` — `--pride-gradient` token, `body.pride` strips, `.pride-toggle` styling
- `site.js` — guarded June-detection block, runs before the hover-image early-return so it applies on every page
- `CLAUDE.md` — documented the new behaviour and token

https://claude.ai/code/session_014B16xzx1CepyzncgPFCbKh

---
_Generated by [Claude Code](https://claude.ai/code/session_014B16xzx1CepyzncgPFCbKh)_