### PR TITLE
Make Pride accent more prominent: rainbow nav pill and link underlines

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -205,9 +205,12 @@ resolve to `/simulations/style.css`, etc., and 404.
   `body[data-page]`.
 - Injects the current year into any `[data-year]` node (used in the footer).
 - Pride Month easter egg: during June (`getMonth() === 5`) it adds a `pride`
-  class to `<body>` and reveals the footer `[data-pride-toggle]` button, which
-  CSS uses to draw thin rainbow strips (the `--pride-gradient` token) under the
-  nav and atop the footer. A click toggles the class and persists the choice in
+  class to `<body>` and reveals the footer `[data-pride-toggle]` button. CSS
+  keyed off `body.pride` draws thin rainbow strips (the `--pride-gradient`
+  token) under the nav and atop the footer, recolours the active nav pill, and
+  swaps in-content link underlines to the rainbow gradient (via the
+  `--underline-image` token, which defaults to the solid accent underline). A
+  click toggles the class and persists the choice in
   `localStorage['pride-colours']` (`"on"`/`"off"`, default on, `try/catch`
   guarded). The toggle is hidden and the class absent outside June.
 - Wires up `.hover-image` buttons with `.hover-img` children for the figure
@@ -293,9 +296,9 @@ templates and pushing. GitHub Pages rebuilds on push to `main`.
   missing required fields rather than erroring.
 - **CSS**: all styles live in `style.css`. It uses CSS custom properties
   (`--color-*` and `--text-*` — the previous `--space-*` spacing tokens were
-  removed as unused, plus `--pride-gradient` for the June easter egg) and a
-  `prefers-color-scheme: dark` block. Prefer extending the existing variables
-  over adding hard-coded values.
+  removed as unused, plus `--pride-gradient` and `--underline-image` for the
+  June easter egg) and a `prefers-color-scheme: dark` block. Prefer extending
+  the existing variables over adding hard-coded values.
 - **JS**: keep `site.js` small and framework-free. It is a single IIFE that
   short-circuits gracefully when the elements it looks for are absent.
 - **Cache busting**: bump `?v=<n>` on `style.css` / `site.js` in

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -31,7 +31,7 @@
   <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
   <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
   <link rel="manifest" href="/site.webmanifest">
-  <link rel="stylesheet" href="/style.css?v=2">
+  <link rel="stylesheet" href="/style.css?v=3">
 
   {% if page.mathjax %}
   <script>

--- a/style.css
+++ b/style.css
@@ -15,6 +15,7 @@
   --color-nav-bg: rgba(24, 15, 12, 0.66);
   --color-focus: #ff9f4a;
   --pride-gradient: linear-gradient(90deg, #e40303, #ff8c00, #ffed00, #008026, #004dff, #750787);
+  --underline-image: linear-gradient(var(--color-accent-strong), var(--color-accent-strong));
 
   --shadow-soft: 0 12px 30px rgba(34, 20, 15, 0.12);
   --shadow-card: 0 6px 18px rgba(34, 20, 15, 0.08);
@@ -86,7 +87,7 @@ img {
 a {
   color: var(--color-accent);
   text-decoration: none;
-  background-image: linear-gradient(var(--color-accent-strong), var(--color-accent-strong));
+  background-image: var(--underline-image);
   background-size: 0% 1.5px;
   background-position: 0 100%;
   background-repeat: no-repeat;
@@ -215,10 +216,21 @@ button:focus-visible {
   color: #ffffff;
 }
 
-/* Pride Month easter egg: thin rainbow strips under the nav and atop the footer. */
+/* Pride Month easter egg: thin rainbow strips under the nav and atop the footer,
+   plus a rainbow active nav pill and in-content link underlines. */
+body.pride {
+  --underline-image: var(--pride-gradient);
+}
+
 body.pride .site-nav {
   border-bottom: 3px solid transparent;
   border-image: var(--pride-gradient) 1;
+}
+
+body.pride .site-nav a[aria-current="page"] {
+  background: var(--pride-gradient);
+  color: #ffffff;
+  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.55);
 }
 
 main {


### PR DESCRIPTION
Follow-up to #41 — makes the June Pride easter egg slightly more prominent by bringing the rainbow into the page body, not just the edges. Both effects are gated on the existing `body.pride` class, so the footer opt-out still removes them.

- **Active nav pill** recolours from solid maroon to the rainbow gradient, with a subtle dark `text-shadow` so the white label stays legible over the flag's bright yellow band.
- **In-content link underlines** turn rainbow via a new `--underline-image` token (defaults to the existing solid-accent underline; swapped under `body.pride`). Using a variable avoids any selector-specificity fight — nav links, site name, `.button-link`, and the footer `secret-dot` keep their `background-image: none`.
- The existing thin nav/footer strips and the toggle are unchanged.

Files: `style.css`, `_layouts/default.html` (cache-bust `?v=3`), `CLAUDE.md`.

https://claude.ai/code/session_014B16xzx1CepyzncgPFCbKh

---
_Generated by [Claude Code](https://claude.ai/code/session_014B16xzx1CepyzncgPFCbKh)_