### PR TITLE
Revert rainbow nav pill, keep rainbow link underlines

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -207,10 +207,10 @@ resolve to `/simulations/style.css`, etc., and 404.
 - Pride Month easter egg: during June (`getMonth() === 5`) it adds a `pride`
   class to `<body>` and reveals the footer `[data-pride-toggle]` button. CSS
   keyed off `body.pride` draws thin rainbow strips (the `--pride-gradient`
-  token) under the nav and atop the footer, recolours the active nav pill, and
-  swaps in-content link underlines to the rainbow gradient (via the
-  `--underline-image` token, which defaults to the solid accent underline). A
-  click toggles the class and persists the choice in
+  token) under the nav and atop the footer and swaps in-content link underlines
+  to the rainbow gradient (via the `--underline-image` token, which defaults to
+  the solid accent underline). A click toggles the class and persists the choice
+  in
   `localStorage['pride-colours']` (`"on"`/`"off"`, default on, `try/catch`
   guarded). The toggle is hidden and the class absent outside June.
 - Wires up `.hover-image` buttons with `.hover-img` children for the figure

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -31,7 +31,7 @@
   <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
   <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
   <link rel="manifest" href="/site.webmanifest">
-  <link rel="stylesheet" href="/style.css?v=3">
+  <link rel="stylesheet" href="/style.css?v=4">
 
   {% if page.mathjax %}
   <script>

--- a/style.css
+++ b/style.css
@@ -217,7 +217,7 @@ button:focus-visible {
 }
 
 /* Pride Month easter egg: thin rainbow strips under the nav and atop the footer,
-   plus a rainbow active nav pill and in-content link underlines. */
+   plus rainbow in-content link underlines. */
 body.pride {
   --underline-image: var(--pride-gradient);
 }
@@ -225,12 +225,6 @@ body.pride {
 body.pride .site-nav {
   border-bottom: 3px solid transparent;
   border-image: var(--pride-gradient) 1;
-}
-
-body.pride .site-nav a[aria-current="page"] {
-  background: var(--pride-gradient);
-  color: #ffffff;
-  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.55);
 }
 
 main {


### PR DESCRIPTION
Removes the rainbow active-nav-pill recolour added in #42 while keeping the rainbow in-content link underlines. The `body.pride .site-nav a[aria-current="page"]` rule (and its text-shadow) is dropped; the `--underline-image` swap under `body.pride` and the thin nav/footer strips remain.

Files: `style.css`, `_layouts/default.html` (cache-bust `?v=4`), `CLAUDE.md`.

https://claude.ai/code/session_014B16xzx1CepyzncgPFCbKh

---
_Generated by [Claude Code](https://claude.ai/code/session_014B16xzx1CepyzncgPFCbKh)_