### PR TITLE
Link mathpr-digest from secret index

### DIFF
--- a/secret.html
+++ b/secret.html
@@ -87,6 +87,15 @@ sitemap: false
       </section>
 
       <section class="page-section reading-width">
+        <h2>Other</h2>
+        <p>Content served under <code>gracar.org</code> but built from a
+        separate repository, so it does not appear in the listings above.</p>
+        <ul>
+          <li><a href="/mathpr-digest/">/mathpr-digest/</a> — Math arXiv preprint digest</li>
+        </ul>
+      </section>
+
+      <section class="page-section reading-width">
         <h2>Sitemap &amp; robots</h2>
         <ul>
           <li><a href="sitemap.xml">/sitemap.xml</a></li>


### PR DESCRIPTION
Adds an "Other" section to `secret.html` linking to `/mathpr-digest/`, which is served under gracar.org but built from a separate repository and so never appears in the auto-generated listings.

https://claude.ai/code/session_011zFducPKzGyqP7k13sNghQ

---
_Generated by [Claude Code](https://claude.ai/code/session_011zFducPKzGyqP7k13sNghQ)_