### PR TITLE
Show discontinuous detection percolation on research page

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,16 +57,22 @@ simulations/                All interactive simulation HTML lives here, and is
                               at simulations/levy-vs-bm.html.
   detection-percolation.html  Embedded simulation: hitting time for a moving
                               Poisson particle system (first contact or first
-                              coverage by the largest connected component).
-                              Jekyll-wrapped, linked from research.html at
-                              simulations/detection-percolation.html.
+                              coverage by the largest connected component), with
+                              Lévy motion smoothed into a continuous glide.
+                              Jekyll-wrapped but **superseded** by the
+                              discontinuous variant below: it is marked
+                              no_index and is no longer linked from
+                              research.html (retained, so its URL and standalone
+                              copy still work, and it stays listed on
+                              secret.html).
   detection-percolation-discontinuous.html  Embedded simulation: a variant of
                               detection-percolation.html where Lévy motion is
                               drawn as a *genuine discontinuous jump process*
                               (particles dwell, then jump instantly, with a
                               fading line marking each leap) while Brownian
-                              motion stays continuous. Jekyll-wrapped, linked
-                              from research.html at
+                              motion stays continuous. Jekyll-wrapped, and the
+                              detection-percolation sim now linked from
+                              research.html at
                               simulations/detection-percolation-discontinuous.html.
   contact-process-standalone.html   Self-contained (Tailwind + MathJax via CDN)
   levy-vs-bm-standalone.html        copy of each simulation for offline /
@@ -250,12 +256,15 @@ at `/simulations/<name>.html`. There are two flavours:
 - **Jekyll-wrapped** — `simulations/contact-process.html`,
   `simulations/levy-vs-bm.html`, `simulations/detection-percolation.html`, and
   `simulations/detection-percolation-discontinuous.html`
-  use `layout: default` and are linked from `research.html` via the relative
-  paths `simulations/<name>.html`. Their public URLs are
-  `gracar.org/simulations/<name>.html`; the `canonical:` field in each page's
-  front matter must match. Do **not** add a `permalink:` field to bring them
-  back to the site root — the layout's nav and asset hrefs assume pages are
-  addressed by their source path.
+  use `layout: default` and are addressed by the relative paths
+  `simulations/<name>.html`. `research.html` links contact-process, levy-vs-bm,
+  and detection-percolation-**discontinuous**; the plain
+  `detection-percolation.html` is now `no_index` and **not** linked (superseded
+  by the discontinuous variant), though it is still a Jekyll page served at its
+  URL. Their public URLs are `gracar.org/simulations/<name>.html`; the
+  `canonical:` field in each page's front matter must match. Do **not** add a
+  `permalink:` field to bring them back to the site root — the layout's nav and
+  asset hrefs assume pages are addressed by their source path.
 - **Standalone** — `simulations/contact-process-standalone.html`,
   `simulations/levy-vs-bm-standalone.html`,
   `simulations/detection-percolation-standalone.html`, and

--- a/research.html
+++ b/research.html
@@ -26,8 +26,7 @@ mathjax: true
     <ul class="reading-width">
       <li><a href="simulations/contact-process.html">Contact process on a mobile geometric graph</a> - a live SIS epidemic spreading through nodes that move by Lévy flight and connect via Pareto-distributed radii.</li>
       <li><a href="simulations/levy-vs-bm.html">Lévy flight vs Brownian motion</a> - a visual comparison of the two processes showing how heavy-tailed jumps produce qualitatively different path geometry.</li>
-      <li><a href="simulations/detection-percolation.html">Detection percolation</a> - hitting time for a moving Poisson particle system, either by first contact with any particle or by first coverage by the largest connected component.</li>
-      <li><a href="simulations/detection-percolation-discontinuous.html">Detection percolation (discontinuous Lévy)</a> - the same model with Lévy motion drawn as a genuine jump process: particles rest, then leap instantly, while Brownian motion stays continuous.</li>
+      <li><a href="simulations/detection-percolation-discontinuous.html">Detection percolation</a> - hitting time for a moving Poisson particle system (first contact with any particle, or coverage by the largest connected component), with Lévy motion drawn as a genuine jump process — particles rest, then leap instantly — while Brownian motion stays continuous.</li>
     </ul>
 	</section>
 

--- a/simulations/detection-percolation.html
+++ b/simulations/detection-percolation.html
@@ -6,6 +6,7 @@ description: "Interactive simulation of the hitting time for a moving Poisson pa
 og_description: "Interactive visualisation of detection percolation — the hitting time when a target particle is covered by a moving Poisson particle system, under either first-contact or largest-component coverage."
 canonical: "https://gracar.org/simulations/detection-percolation.html"
 mathjax: true
+no_index: true   # superseded by detection-percolation-discontinuous.html; kept but unlinked and out of the sitemap
 ---
 <script src="https://cdn.tailwindcss.com"></script>
 <style>


### PR DESCRIPTION
Makes the discontinuous-Lévy variant the detection percolation sim shown on the research page, and retires the continuous embedded version from public view (scope: **unlink + de-index**).

## Changes
- **`research.html`** — collapse the two detection-percolation list items into one linking `detection-percolation-discontinuous.html`, relabelled as the primary "Detection percolation" entry.
- **`simulations/detection-percolation.html`** — add `no_index: true`, so it drops out of `sitemap.xml` (the Liquid loop skips `p.no_index`) and is tagged `(noindex)` on `/secret`. The file, its canonical URL, and the standalone copy are otherwise untouched — kept but unlinked and de-indexed.
- **`CLAUDE.md`** — document that the discontinuous variant is the shown detection percolation sim and the continuous embedded page is superseded / `no_index` / unlinked.

## Verification
`research.html` now has exactly one detection-percolation link, pointing at the discontinuous page; the continuous page carries `no_index` while the discontinuous page does not, so the sitemap will keep the latter and drop the former on the next build. No changes needed to `sitemap.xml` or `secret.html` — both react automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NVq8vSzAarL5DeUGk539BZ)_