### PR TITLE
Extend file-date tracking to all pages and files

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -29,21 +29,21 @@ jobs:
           # those commits).
           fetch-depth: 0
 
-      - name: Record upload dates from git history
-        # secret.html shows, next to each uploads/ file, the date it was
-        # added. We can't rely on filesystem mtimes: actions/checkout
-        # stamps every file with the checkout time, and an mtime restored
-        # on the runner does not reliably survive the Dockerised Jekyll
-        # build (which left every upload dated to the build time). Instead
-        # write the date of the last commit that touched each upload into
-        # _data/upload_dates.json, which Jekyll reads deterministically as
-        # site.data.upload_dates. The file is generated here at build time
-        # and never committed (see .gitignore), so it does not itself
-        # churn the git history.
+      - name: Record last-update dates from git history
+        # secret.html shows, next to every page and file it lists, the date
+        # that file was last updated. We can't rely on filesystem mtimes:
+        # actions/checkout stamps every file with the checkout time, and an
+        # mtime restored on the runner does not reliably survive the
+        # Dockerised Jekyll build (which left every file dated to the build
+        # time). Instead write the date of the last commit that touched each
+        # tracked file into _data/file_dates.json, keyed by repo-relative
+        # path, which Jekyll reads deterministically as site.data.file_dates.
+        # The file is generated here at build time and never committed (see
+        # .gitignore), so it does not itself churn the git history.
         run: |
           python3 - <<'PY'
           import subprocess, json, os
-          files = subprocess.check_output(['git', 'ls-files', 'uploads/']).decode().splitlines()
+          files = subprocess.check_output(['git', 'ls-files']).decode().splitlines()
           dates = {}
           for f in files:
               if os.path.basename(f).startswith('.'):
@@ -53,7 +53,7 @@ jobs:
               if d:
                   dates[f] = d
           os.makedirs('_data', exist_ok=True)
-          with open('_data/upload_dates.json', 'w') as fh:
+          with open('_data/file_dates.json', 'w') as fh:
               json.dump(dates, fh, indent=2, ensure_ascii=False)
               fh.write('\n')
           PY

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 .DS_Store
 /.claude
-# Generated at build time by pages.yml (upload "added" dates); never committed.
-/_data/upload_dates.json
+# Generated at build time by pages.yml (per-file last-update dates); never committed.
+/_data/file_dates.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -136,7 +136,7 @@ site.webmanifest, favicon*, apple-touch-icon, android-chrome-*  PWA icons
 .github/workflows/pages.yml GitHub Actions workflow that builds with Jekyll
                             and deploys to GitHub Pages on push to main.
 .gitignore                  Ignores .DS_Store, /.claude, and the build-time
-                            /_data/upload_dates.json (see secret.html notes)
+                            /_data/file_dates.json (see secret.html notes)
 ```
 
 There is no `Gemfile`, `package.json`, or test suite — the only automation is
@@ -334,19 +334,22 @@ counterpart; its two HTML files must be kept in sync with each other.
   the author without adding them to the public sitemap. The "Uploads" section
   lists every static file whose path contains `/uploads/` (any extension); the
   HTML and PDF sections exclude `/uploads/` paths so an uploaded HTML/PDF is
-  not listed twice. Each upload also shows the date it was added, looked up
-  from `site.data.upload_dates` (keyed by the file's repo-relative path, e.g.
-  `uploads/<name>`). That data file, `_data/upload_dates.json`, is **generated
-  at build time** by `pages.yml`: a step runs `git log -1 --format=%cs` for
-  every tracked `uploads/` file and records the date of the last commit that
-  touched it. Filesystem mtimes are deliberately **not** used — `actions/checkout`
-  stamps every file with the checkout time, and an mtime restored on the runner
-  (e.g. via `git-restore-mtime`) did not reliably survive the Dockerised
-  `jekyll-build-pages` step, leaving every upload dated to the build time. The
-  full-history checkout (`fetch-depth: 0`) is required so `git log` can see the
-  original commits. `_data/upload_dates.json` is git-ignored and never
-  committed, so generating it does not churn history; absent it (e.g. a plain
-  local build), uploads simply render with no date.
+  not listed twice. Every entry in the Pages, Standalone HTML, Papers & PDFs,
+  and Uploads sections shows the date the file was **last updated**, looked up
+  from `site.data.file_dates` (keyed by the file's repo-relative path — e.g.
+  `uploads/<name>` for static files, resolved via `f.path | remove_first: "/"`,
+  and `p.path` for Jekyll pages such as `research.html` or
+  `simulations/contact-process.html`). That data file, `_data/file_dates.json`,
+  is **generated at build time** by `pages.yml`: a step runs
+  `git log -1 --format=%cs` for **every tracked file** and records the date of
+  the last commit that touched it. Filesystem mtimes are deliberately **not**
+  used — `actions/checkout` stamps every file with the checkout time, and an
+  mtime restored on the runner (e.g. via `git-restore-mtime`) did not reliably
+  survive the Dockerised `jekyll-build-pages` step, leaving every file dated to
+  the build time. The full-history checkout (`fetch-depth: 0`) is required so
+  `git log` can see the original commits. `_data/file_dates.json` is git-ignored
+  and never committed, so generating it does not churn history; absent it (e.g.
+  a plain local build), entries simply render with no date.
   It also renders a small "Build info" panel using `site.time` (the build
   timestamp, always available) and `site.github.build_revision` /
   `site.github.repository_nwo` from the `jekyll-github-metadata` plugin (which

--- a/secret.html
+++ b/secret.html
@@ -44,15 +44,18 @@ sitemap: false
       <section class="page-section reading-width">
         <h2>Pages</h2>
         <p>Jekyll pages with front matter (<code>site.pages</code>). Entries
-        flagged <em>(noindex)</em> are excluded from the public sitemap.</p>
+        flagged <em>(noindex)</em> are excluded from the public sitemap. The
+        date is when the file was last updated (its last commit in git).</p>
         <ul>
           {%- assign pages = site.pages | sort: "url" -%}
           {%- for p in pages -%}
             {%- unless p.url == "/secret.html" or p.url contains "sitemap" %}
+              {%- assign updated = site.data.file_dates[p.path] -%}
           <li>
             <a href="{{ p.url }}">{{ p.url }}</a>
             {%- if p.title %} — {{ p.title }}{%- endif -%}
             {%- if p.no_index %} <em>(noindex)</em>{%- endif -%}
+            {%- if updated %} — <time datetime="{{ updated }}">{{ updated }}</time>{%- endif -%}
           </li>
             {%- endunless -%}
           {%- endfor %}
@@ -63,13 +66,19 @@ sitemap: false
         <h2>Standalone HTML files</h2>
         <p>HTML files with no Jekyll front matter — copied through as static
         assets (<code>site.static_files</code>). These are not in the sitemap
-        and are not linked from the navigation.</p>
+        and are not linked from the navigation. The date is when the file was
+        last updated (its last commit in git).</p>
         <ul>
           {%- assign statics = site.static_files | sort: "path" -%}
           {%- for f in statics -%}
             {%- if f.extname == ".html" -%}
               {%- unless f.path contains "/uploads/" %}
-          <li><a href="{{ f.path }}">{{ f.path }}</a></li>
+                {%- assign key = f.path | remove_first: "/" -%}
+                {%- assign updated = site.data.file_dates[key] -%}
+          <li>
+            <a href="{{ f.path }}">{{ f.path }}</a>
+            {%- if updated %} — <time datetime="{{ updated }}">{{ updated }}</time>{%- endif -%}
+          </li>
               {%- endunless -%}
             {%- endif -%}
           {%- endfor %}
@@ -78,12 +87,18 @@ sitemap: false
 
       <section class="page-section reading-width">
         <h2>Papers &amp; PDFs</h2>
-        <p>Direct links to every PDF served from the repository.</p>
+        <p>Direct links to every PDF served from the repository. The date is
+        when the file was last updated (its last commit in git).</p>
         <ul>
           {%- for f in statics -%}
             {%- if f.extname == ".pdf" -%}
               {%- unless f.path contains "/uploads/" %}
-          <li><a href="{{ f.path }}">{{ f.path }}</a></li>
+                {%- assign key = f.path | remove_first: "/" -%}
+                {%- assign updated = site.data.file_dates[key] -%}
+          <li>
+            <a href="{{ f.path }}">{{ f.path }}</a>
+            {%- if updated %} — <time datetime="{{ updated }}">{{ updated }}</time>{%- endif -%}
+          </li>
               {%- endunless -%}
             {%- endif -%}
           {%- endfor %}
@@ -95,15 +110,15 @@ sitemap: false
         <p>Files placed in <code>uploads/</code> — served as static assets at
         <code>/uploads/&lt;name&gt;</code>. These are excluded from the sitemap
         and <code>robots.txt</code>, and are not linked from the navigation.
-        The date is when the file was added (its last commit in git).</p>
+        The date is when the file was last updated (its last commit in git).</p>
         <ul>
           {%- for f in statics -%}
             {%- if f.path contains "/uploads/" %}
-              {%- assign upload_key = f.path | remove_first: "/" -%}
-              {%- assign added = site.data.upload_dates[upload_key] -%}
+              {%- assign key = f.path | remove_first: "/" -%}
+              {%- assign updated = site.data.file_dates[key] -%}
           <li>
             <a href="{{ f.path }}">{{ f.path }}</a>
-            {%- if added %} — <time datetime="{{ added }}">{{ added }}</time>{%- endif -%}
+            {%- if updated %} — <time datetime="{{ updated }}">{{ updated }}</time>{%- endif -%}
           </li>
             {%- endif -%}
           {%- endfor %}


### PR DESCRIPTION
Generalize the per-file last-update date tracking from uploads only to all pages, static files, PDFs, and HTML files listed on `secret.html`. This provides consistent, git-sourced timestamps across the entire site inventory.

**Changes:**

- **`secret.html`**: Extended date display to Pages, Standalone HTML, and Papers & PDFs sections (previously only Uploads showed dates). Updated all three sections to look up dates from `site.data.file_dates` using the appropriate key format (`p.path` for Jekyll pages, `f.path | remove_first: "/"` for static files). Unified variable naming from `added`/`upload_key` to `updated`/`key` for consistency. Updated descriptive text to clarify that dates reflect last-update time from git history.

- **`.github/workflows/pages.yml`**: Expanded the git-log step to track **all** files (`git ls-files` without the `uploads/` filter) instead of just uploads. Renamed the generated data file from `_data/upload_dates.json` to `_data/file_dates.json` and updated the step name and comments to reflect the broader scope.

- **`.gitignore`**: Updated the ignored file path and comment to reference `_data/file_dates.json`.

- **`CLAUDE.md`**: Updated documentation to describe the new unified file-dates system, clarifying that all pages and files now show last-update dates keyed by repo-relative path, and that the data file is generated at build time for all tracked files.

**Implementation notes:**

- The date lookup uses consistent key formats: Jekyll pages use `p.path` directly (e.g. `research.html`, `simulations/contact-process.html`), while static files use `f.path | remove_first: "/"` to strip the leading slash (e.g. `uploads/file.pdf`).
- Dates are optional; entries render without a date if the file is absent from the data (e.g. during local builds without the workflow step).
- The full-history checkout (`fetch-depth: 0`) remains required so `git log` can access original commits.

https://claude.ai/code/session_01HEz3APPDPGZFgSdnsrcog3