### PR TITLE
Disallow /secret.html in robots.txt

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -329,7 +329,8 @@ counterpart; its two HTML files must be kept in sync with each other.
   automatically.
 - `secret.html` is an unlisted full index of pages, static HTML files, PDFs,
   and `uploads/` files. It is marked `no_index`, `no_analytics`,
-  `sitemap: false`, and excludes itself from its own list. It exists so
+  `sitemap: false`, disallowed in `robots.txt`, and excludes itself from its
+  own list. It exists so
   standalone simulations, reprints, and uploaded files remain discoverable to
   the author without adding them to the public sitemap. The "Uploads" section
   lists every static file whose path contains `/uploads/` (any extension); the

--- a/robots.txt
+++ b/robots.txt
@@ -1,5 +1,6 @@
 User-agent: *
 Allow: /
 Disallow: /uploads/
+Disallow: /secret.html
 
 Sitemap: https://gracar.org/sitemap.xml


### PR DESCRIPTION
Adds `Disallow: /secret.html` to `robots.txt` so compliant crawlers won't request the unlisted index page (it was already `no_index` and excluded from the sitemap). Also updates the `secret.html` note in `CLAUDE.md` to reflect this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01J4yd8ZUUjEwh5SVHxyJmDc)_